### PR TITLE
fix: Add explicit float32 dtype to np.zeros in FaceIdentity

### DIFF
--- a/python/inspireface/modules/inspireface.py
+++ b/python/inspireface/modules/inspireface.py
@@ -874,7 +874,7 @@ def feature_hub_face_search(data: np.ndarray) -> SearchResult:
         search_identity = FaceIdentity.from_ctypes(most_similar)
         return SearchResult(confidence=confidence.value, similar_identity=search_identity)
     else:
-        none = FaceIdentity(np.zeros(0), most_similar.id)
+        none = FaceIdentity(np.zeros(0, dtype=np.float32), most_similar.id)
         return SearchResult(confidence=confidence.value, similar_identity=none)
 
 


### PR DESCRIPTION
## Description
When creating an empty array in FaceIdentity, the dtype was not explicitly specified, causing type check failures. This fix ensures the empty array is created with the correct float32 dtype.

## Changes Made
- Modified `np.zeros(0)` to `np.zeros(0, dtype=np.float32)`
- Ensures consistent dtype handling throughout the face recognition pipeline

## Problem
When processing images, FaceIdentity creation would fail with a ValueError stating "The input data must be in float32 format", even though the input data appeared to be in the correct format.

## Solution
Explicitly specify float32 dtype when creating empty arrays to ensure type consistency.

## Testing
- Tested with both JPG and PNG image formats
- Verified that face recognition pipeline works correctly with the modified code
- Confirmed that type check errors no longer occur

## Additional Notes
This issue was particularly noticeable when processing PNG images, but the fix ensures consistent behavior across all image formats.