### PR TITLE
Fix Compile error on iOS for Track Cost Spend

### DIFF
--- a/cpp/inspireface/c_api/inspireface.cc
+++ b/cpp/inspireface/c_api/inspireface.cc
@@ -649,7 +649,7 @@ HResult HFGetFaceFiveKeyPointsFromFaceToken(HFFaceBasicToken singleFace, HPoint2
     return HSUCCEED;
 }
 
-HResult HFSessionSetEnableTrackCostSpend(HFSession session, bool value) {
+HResult HFSessionSetEnableTrackCostSpend(HFSession session, int value) {
     if (session == nullptr) {
         return HERR_INVALID_CONTEXT_HANDLE;
     }

--- a/cpp/inspireface/c_api/inspireface.h
+++ b/cpp/inspireface/c_api/inspireface.h
@@ -559,7 +559,7 @@ HYPER_CAPI_EXPORT extern HResult HFGetFaceFiveKeyPointsFromFaceToken(HFFaceBasic
  * @param value The enable cost spend value
  * @return int32_t Status code of the operation.
  * */
-HYPER_CAPI_EXPORT extern HResult HFSessionSetEnableTrackCostSpend(HFSession session, bool value);
+HYPER_CAPI_EXPORT extern HResult HFSessionSetEnableTrackCostSpend(HFSession session, int value);
 
 /**
  * @brief Print the cost spend

--- a/cpp/inspireface/face_session.cpp
+++ b/cpp/inspireface/face_session.cpp
@@ -416,7 +416,7 @@ int32_t FaceSession::SetTrackModeDetectInterval(int value) {
     return HSUCCEED;
 }
 
-int32_t FaceSession::SetEnableTrackCostSpend(bool value) {
+int32_t FaceSession::SetEnableTrackCostSpend(int value) {
     m_enable_track_cost_spend_ = value;
     m_face_track_cost_->Reset();
     return HSUCCEED;

--- a/cpp/inspireface/face_session.h
+++ b/cpp/inspireface/face_session.h
@@ -340,7 +340,7 @@ public:
      * @param value The enable cost spend value
      * @return int32_t Status code of the operation.
      * */
-    int32_t SetEnableTrackCostSpend(bool value);
+    int32_t SetEnableTrackCostSpend(int value);
 
     /**
      * @brief Print the cost spend
@@ -392,7 +392,7 @@ private:
     // cost spend
     std::shared_ptr<inspirecv::TimeSpend> m_face_track_cost_;
 
-    bool m_enable_track_cost_spend_ = false;
+    int m_enable_track_cost_spend_ = 0;
 };
 
 }  // namespace inspire

--- a/cpp/sample/api/sample_face_track_benchmark.cpp
+++ b/cpp/sample/api/sample_face_track_benchmark.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
     int loop = 100;
 
     // Enable the cost spend
-    HFSessionSetEnableTrackCostSpend(session, true);
+    HFSessionSetEnableTrackCostSpend(session, 1);
 
     // Execute HF_FaceContextRunFaceTrack captures face information in an image
     HFMultipleFaceData multipleFaceData = {0};


### PR DESCRIPTION
When the _Track Cost Spend_ feature was introduced, it broke the iOS SDK integration, since `bool` is not supported in C.

- Updated the Track Cost Spend to use `int` instead of `bool`