### PR TITLE
Fix the issue of the default preview size

### DIFF
--- a/cpp/inspireface/c_api/inspireface.cc
+++ b/cpp/inspireface/c_api/inspireface.cc
@@ -548,6 +548,20 @@ HResult HFSessionSetTrackPreviewSize(HFSession session, HInt32 previewSize) {
     return ctx->impl.SetTrackPreviewSize(previewSize);
 }
 
+HResult HFSessionGetTrackPreviewSize(HFSession session, HInt32 *previewSize) {
+    if (session == nullptr) {
+        return HERR_INVALID_CONTEXT_HANDLE;
+    }
+    HF_FaceAlgorithmSession *ctx = (HF_FaceAlgorithmSession *)session;
+    if (ctx == nullptr) {
+        return HERR_INVALID_CONTEXT_HANDLE;
+    }
+    *previewSize = ctx->impl.GetTrackPreviewSize();
+    return HSUCCEED;
+}
+
+
+
 HResult HFSessionSetFilterMinimumFacePixelSize(HFSession session, HInt32 minSize) {
     if (session == nullptr) {
         return HERR_INVALID_CONTEXT_HANDLE;
@@ -644,6 +658,18 @@ HResult HFExecuteFaceTrack(HFSession session, HFImageStream streamHandle, PHFMul
     results->tokens = (HFFaceBasicToken *)ctx->impl.GetFaceBasicDataCache().data();
 
     return ret;
+}
+
+HResult HFSessionLastFaceDetectionGetDebugPreviewImageSize(HFSession session, HInt32 *size) {
+    if (session == nullptr) {
+        return HERR_INVALID_CONTEXT_HANDLE;
+    }
+    HF_FaceAlgorithmSession *ctx = (HF_FaceAlgorithmSession *)session;
+    if (ctx == nullptr) {
+        return HERR_INVALID_CONTEXT_HANDLE;
+    }
+    *size = ctx->impl.GetDebugPreviewImageSize();
+    return HSUCCEED;
 }
 
 HResult HFCopyFaceBasicToken(HFFaceBasicToken token, HPBuffer buffer, HInt32 bufferSize) {

--- a/cpp/inspireface/c_api/inspireface.h
+++ b/cpp/inspireface/c_api/inspireface.h
@@ -492,6 +492,14 @@ typedef struct HFMultipleFaceData {
 HYPER_CAPI_EXPORT extern HResult HFSessionSetTrackPreviewSize(HFSession session, HInt32 previewSize);
 
 /**
+ * @brief Get the track preview size in the session.
+ * @param session Handle to the session.
+ * @param previewSize The size of the preview for tracking.
+ * @return HResult indicating the success or failure of the operation.
+ */
+HYPER_CAPI_EXPORT extern HResult HFSessionGetTrackPreviewSize(HFSession session, HInt32 *previewSize);
+
+/**
  * @brief Set the minimum number of face pixels that the face detector can capture, and people below
  * this number will be filtered.
  *
@@ -546,6 +554,14 @@ HYPER_CAPI_EXPORT extern HResult HFSessionSetTrackModeDetectInterval(HFSession s
  * @return HResult indicating the success or failure of the operation.
  */
 HYPER_CAPI_EXPORT extern HResult HFExecuteFaceTrack(HFSession session, HFImageStream streamHandle, PHFMultipleFaceData results);
+
+/**
+ * @brief Gets the size of the debug preview image for the last face detection in the session.
+ * @param session Handle to the session.
+ * @param size The size of the preview for tracking.
+ * @return HResult indicating the success or failure of the operation.
+ */
+HYPER_CAPI_EXPORT extern HResult HFSessionLastFaceDetectionGetDebugPreviewImageSize(HFSession session, HInt32 *size);
 
 /**
  * @brief Copies the data from a HF_FaceBasicToken to a specified buffer.

--- a/cpp/inspireface/engine/face_session.cpp
+++ b/cpp/inspireface/engine/face_session.cpp
@@ -423,6 +423,10 @@ int32_t FaceSession::SetTrackPreviewSize(const int32_t preview_size) {
     return HSUCCEED;
 }
 
+int32_t FaceSession::GetTrackPreviewSize() const {
+    return m_face_track_->GetTrackPreviewSize();
+}
+
 int32_t FaceSession::SetTrackFaceMinimumSize(int32_t minSize) {
     m_face_track_->SetMinimumFacePxSize(minSize);
     return HSUCCEED;
@@ -453,6 +457,10 @@ void FaceSession::PrintTrackCostSpend() {
     if (m_enable_track_cost_spend_) {
         INSPIRE_LOGI("%s", m_face_track_cost_->Report().c_str());
     }
+}
+
+int32_t FaceSession::GetDebugPreviewImageSize() const {
+    return m_face_track_->GetDebugPreviewImageSize();
 }
 
 }  // namespace inspire

--- a/cpp/inspireface/engine/face_session.h
+++ b/cpp/inspireface/engine/face_session.h
@@ -156,6 +156,12 @@ public:
     int32_t SetTrackPreviewSize(int32_t preview_size);
 
     /**
+     * @brief Gets the preview size for face tracking.
+     * @return int32_t The preview size.
+     */
+    int32_t GetTrackPreviewSize() const;
+
+    /**
      * @brief Filter the minimum face pixel size.
      * @param minSize The minimum pixel value.
      * @return int32_t Status code of the operation.
@@ -353,6 +359,12 @@ public:
      * @brief Print the cost spend
      * */
     void PrintTrackCostSpend();
+
+    /**
+     * @brief Get the debug preview image size
+     * @return int32_t The debug preview image size
+     * */
+    int32_t GetDebugPreviewImageSize() const;
 
 private:
     // Private member variables

--- a/cpp/inspireface/track_module/face_detect/face_detect_adapt.cpp
+++ b/cpp/inspireface/track_module/face_detect/face_detect_adapt.cpp
@@ -154,4 +154,8 @@ bool SortBoxSizeAdapt(const FaceLoc &a, const FaceLoc &b) {
     return sq_a > sq_b;
 }
 
+int FaceDetectAdapt::GetInputSize() const {
+    return m_input_size_;
+}
+
 }  // namespace inspire

--- a/cpp/inspireface/track_module/face_detect/face_detect_adapt.h
+++ b/cpp/inspireface/track_module/face_detect/face_detect_adapt.h
@@ -41,6 +41,12 @@ public:
     /** @brief Set face classification threshold */
     void SetClsThreshold(float mClsThreshold);
 
+    /**
+     * @brief Get the input size
+     * @return int The input size
+     */
+    int GetInputSize() const;
+
 private:
     /**
      * @brief Applies non-maximum suppression to reduce overlapping detected faces.

--- a/cpp/inspireface/track_module/face_track_module.h
+++ b/cpp/inspireface/track_module/face_track_module.h
@@ -34,7 +34,7 @@ public:
      * @param track_preview_size Size of the preview for tracking.
      * @param dynamic_detection_input_level Change the detector input size.
      */
-    explicit FaceTrackModule(DetectModuleMode mode, int max_detected_faces = 1, int detection_interval = 20, int track_preview_size = 192,
+    explicit FaceTrackModule(DetectModuleMode mode, int max_detected_faces = 1, int detection_interval = 20, int track_preview_size = -1,
                              int dynamic_detection_input_level = -1, int TbD_mode_fps = 30, bool detect_mode_landmark = true);
 
     /**
@@ -56,7 +56,13 @@ public:
      * @brief Sets the preview size for tracking.
      * @param preview_size Size of the preview for tracking.
      */
-    void SetTrackPreviewSize(int preview_size = 192);
+    void SetTrackPreviewSize(int preview_size = -1);
+
+    /**
+     * @brief Gets the preview size for tracking.
+     * @return Size of the preview for tracking.
+     */
+    int32_t GetTrackPreviewSize() const;
 
 private:
     /**
@@ -130,7 +136,7 @@ private:
      * @param pixel_size Currently, only 160, 320, and 640 pixel sizes are supported.
      * @return Return the corresponding scheme name, only ”face_detect_160”, ”face_detect_320”, ”face_detect_640” are supported.
      */
-    std::string ChoiceMultiLevelDetectModel(const int32_t pixel_size);
+    std::string ChoiceMultiLevelDetectModel(const int32_t pixel_size, int32_t& final_size);
 
 public:
     /**
@@ -170,6 +176,9 @@ public:
 public:
     std::vector<FaceObjectInternal> trackingFace;  ///< Vector of FaceObjects currently being tracked.
 
+public:
+    int32_t GetDebugPreviewImageSize() const;
+
 private:
     const int max_detected_faces_;                     ///< Maximum number of faces to detect.
     std::vector<FaceObjectInternal> candidate_faces_;  ///< Vector of candidate FaceObjects for tracking.
@@ -178,6 +187,10 @@ private:
     int tracking_idx_;                                 ///< Current tracking index.
     int track_preview_size_;                           ///< Size of the tracking preview.
     int filter_minimum_face_px_size = 0;               ///< Minimum face pixel allowed to be retained (take the edge with the smallest Rect).
+
+private:
+    // Debug cache
+    int32_t m_debug_preview_image_size_{0};  ///< Debug preview image size
 
 private:
     std::shared_ptr<FaceDetectAdapt> m_face_detector_;         ///< Shared pointer to the face detector.


### PR DESCRIPTION
#207 By default, the size at the detector level is used to eliminate the problem of image detail loss caused by it.