### PR TITLE
fix(build): replace im2d.hpp with im2d.h to fix RGA compilation on RK3588

### DIFF
--- a/cpp/inspireface/image_process/nexus_processor/image_processor_rga.h
+++ b/cpp/inspireface/image_process/nexus_processor/image_processor_rga.h
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #include <memory>
 #include <unordered_map>
-#include "im2d.hpp"
+#include "im2d.h"
 #include "im2d_single.h"
 #include "RgaUtils.h"
 #include "rga/utils.h"


### PR DESCRIPTION
## Description
This PR fixes a compilation error encountered when building the Android NDK version for RK3588 with RGA enabled.

## Context
When `IS_RGA` is enabled, the build fails because `im2d.hpp` is included in `image_processor_rga.h`. It seems that the RGA library (librga) available in the NDK environment for RK3588 provides `im2d.h` instead of the C++ header `im2d.hpp`.

## Changes
- Modified `cpp/inspireface/image_process/nexus_processor/image_processor_rga.h`: Changed `#include "im2d.hpp"` to `#include "im2d.h"`.

## Verification
- Verified that the compilation passes successfully on Android NDK (RK3588 target) after this change.