### PR TITLE
[fix] typo, from 'opt' to 'param' in isf.InspireFaceSession().

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -38,7 +38,7 @@ import inspireface as isf
 
 # Create session with required features enabled
 session = isf.InspireFaceSession(
-    opt=isf.HF_ENABLE_NONE,  # Optional features
+    param=isf.HF_ENABLE_NONE,  # Optional features
     detect_mode=isf.HF_DETECT_MODE_ALWAYS_DETECT  # Detection mode
 )
 


### PR DESCRIPTION
- get TypeError
  ```log
  (ifpy38) [iwake@wkarch python]$ LD_LIBRARY_PATH=/opt/tensorrt/lib:$LD_LIBRARY_PATH python demo_official.py 
  Exception ignored in: <function InspireFaceSession.__del__ at 0x7f03cb6131f0>
  Traceback (most recent call last):
    File "/home/iwake/.conda/envs/ifpy38/lib/python3.8/site-packages/inspireface-1.2.3-py3.8.egg/inspireface/modules/inspireface.py", line 711, in __del__
      self.release()
    File "/home/iwake/.conda/envs/ifpy38/lib/python3.8/site-packages/inspireface-1.2.3-py3.8.egg/inspireface/modules/inspireface.py", line 706, in release
      if self._sess is not None:
  AttributeError: 'InspireFaceSession' object has no attribute '_sess'
  Traceback (most recent call last):
    File "demo_official.py", line 5, in <module>
      session = isf.InspireFaceSession(
  TypeError: __init__() got an unexpected keyword argument 'opt'
  ```
- I refer
https://github.com/HyperInspire/InspireFace/blob/a04f63e372623762229d9a95ca11960291b34455/python/inspireface/modules/inspireface.py#L290-L326
- So
  ```diff
  session = isf.InspireFaceSession(
  -   opt=isf.HF_ENABLE_NONE,  # Optional features
  +   param=isf.HF_ENABLE_NONE,  # Optional features
      detect_mode=isf.HF_DETECT_MODE_ALWAYS_DETECT  # Detection mode
  )
  ```